### PR TITLE
[ADD] Variant fields: display weight, covered surface, default variant and sale_ok

### DIFF
--- a/product_seeds/__manifest__.py
+++ b/product_seeds/__manifest__.py
@@ -18,6 +18,7 @@
 
     'data': [
         'data/data.xml',
+        'views/product_product.xml',
         'views/product_template.xml',
         'views/seedling_months.xml',
         'security/ir.model.access.csv',

--- a/product_seeds/models/__init__.py
+++ b/product_seeds/models/__init__.py
@@ -1,1 +1,2 @@
 from . import product_template
+from . import product_product

--- a/product_seeds/models/product_product.py
+++ b/product_seeds/models/product_product.py
@@ -1,7 +1,7 @@
 # © 2016 Robin Keunen, Coop IT Easy SCRL fs
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
 
-from odoo import models, fields
+from odoo import models, fields, api
 
 
 class ProductProduct(models.Model):
@@ -13,12 +13,31 @@ class ProductProduct(models.Model):
     variant_sale_ok = fields.Boolean(
         string='Can be Sold (Variant)',
     )
-    # todo set other variants default to false (on change)
     default_variant = fields.Boolean(
         string='Default Variant',
+        compute='_compute_default_variant',
+        inverse='_inverse_default_variant',
+        store=True,
     )
     # todo migrate to many2many
     label = fields.Char(
         string="Label",
     )
     # todo weight unit of measure
+
+    def _compute_default_variant(self):
+        return self.default_variant
+
+    def _inverse_default_variant(self):
+        self.ensure_one()
+        if self.default_variant:
+            other_variants = (
+                self
+                .product_tmpl_id
+                .product_variant_ids
+                .filtered(lambda p: p.id != self.id)
+            )
+            for product in other_variants:
+                product.default_variant = False
+
+        return

--- a/product_seeds/models/product_product.py
+++ b/product_seeds/models/product_product.py
@@ -1,0 +1,24 @@
+# © 2016 Robin Keunen, Coop IT Easy SCRL fs
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+
+from odoo import models, fields
+
+
+class ProductProduct(models.Model):
+    _inherit = 'product.product'
+
+    covered_surface = fields.Float(
+        string='Covered Surface (m²)',
+    )
+    variant_sale_ok = fields.Boolean(
+        string='Can be Sold (Variant)',
+    )
+    # todo set other variants default to false (on change)
+    default_variant = fields.Boolean(
+        string='Default Variant',
+    )
+    # todo migrate to many2many
+    label = fields.Char(
+        string="Label",
+    )
+    # todo weight unit of measure

--- a/product_seeds/views/product_product.xml
+++ b/product_seeds/views/product_product.xml
@@ -20,6 +20,16 @@
                     <field name="covered_surface"/>
                     <field name="label"/>
                 </xpath>
+
+                <xpath expr="//group[@name='weight']" position="inside">
+                    <group>
+                        <field name="display_weight"/>
+                        <field name="weight_unit"/>
+                    </group>
+                </xpath>
+
+                <!-- todo hide weight field -->
+
             </field>
         </record>
 
@@ -29,23 +39,22 @@
             <field name="inherit_id" ref="product.product_normal_form_view"/>
             <field name="arch" type="xml">
 
-                <!-- group attribute selector -->
                 <xpath expr="//page[@name='general_information']" position="after">
                     <page name="variant_information" string="Variant Information">
+                        <field name="attribute_value_ids" widget="many2many_tags" readonly="1" groups="product.group_product_variant"/>
                         <group name="Information">
-                            <field name="attribute_value_ids" widget="many2many_tags" readonly="1" groups="product.group_product_variant"/>
-                            <field name="covered_surface"/>
-                            <field name="weight"/>
-                            <field name="label"/>
+                            <group>
+                                <field name="covered_surface"/>
+                                <field name="label"/>
+                                <field name="display_weight"/>
+                                <field name="weight_unit"/>
+                            </group>
                         </group>
                         <group string="E Commerce" name="ecommerce">
                             <field name="variant_sale_ok"/>
                             <field name="default_variant"/>
                         </group>
                     </page>
-                </xpath>
-
-                <xpath expr="//field[@name='attribute_value_ids']" position="after">
                 </xpath>
             </field>
         </record>

--- a/product_seeds/views/product_product.xml
+++ b/product_seeds/views/product_product.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+
+        <record model="ir.ui.view" id="product_variant_easy_edit_view">
+            <field name="name">product.product.product.form.easy</field>
+            <field name="model">product.product</field>
+            <field name="inherit_id" ref="product.product_variant_easy_edit_view"/>
+            <field name="arch" type="xml">
+
+                <!-- group attribute selector -->
+                <xpath expr="//field[@name='attribute_value_ids']/.." position="before">
+                    <group string="E Commerce" name="ecommerce">
+                        <field name="variant_sale_ok"/>
+                        <field name="default_variant"/>
+                    </group>
+                </xpath>
+
+                <xpath expr="//field[@name='attribute_value_ids']" position="after">
+                    <field name="covered_surface"/>
+                    <field name="label"/>
+                </xpath>
+            </field>
+        </record>
+
+        <record model="ir.ui.view" id="product_normal_form_view">
+            <field name="name">product.product.product.form</field>
+            <field name="model">product.product</field>
+            <field name="inherit_id" ref="product.product_normal_form_view"/>
+            <field name="arch" type="xml">
+
+                <!-- group attribute selector -->
+                <xpath expr="//page[@name='general_information']" position="after">
+                    <page name="variant_information" string="Variant Information">
+                        <group name="Information">
+                            <field name="attribute_value_ids" widget="many2many_tags" readonly="1" groups="product.group_product_variant"/>
+                            <field name="covered_surface"/>
+                            <field name="weight"/>
+                            <field name="label"/>
+                        </group>
+                        <group string="E Commerce" name="ecommerce">
+                            <field name="variant_sale_ok"/>
+                            <field name="default_variant"/>
+                        </group>
+                    </page>
+                </xpath>
+
+                <xpath expr="//field[@name='attribute_value_ids']" position="after">
+                </xpath>
+            </field>
+        </record>
+
+    </data>
+</odoo>


### PR DESCRIPTION
- [14b - Conditionnement et sachets : ajouter champs poids du sachet et surface couverte sur product.product](https://gestion.coopiteasy.be/web#id=1438&view_type=form&model=project.task&menu_id=338&action=479)
- [14c - Conditionnement et sachets: variant standard](https://gestion.coopiteasy.be/web#id=1440&view_type=form&model=project.task&menu_id=338&action=479)
- [14e - Conditionnement et sachets: sale_ok sur les variants](https://gestion.coopiteasy.be/web#id=1441&view_type=form&model=project.task&menu_id=338&action=479)