### PR TITLE
trying hard to sort packages

### DIFF
--- a/cycle_en_terre_custom/report/report_stockpicking_operations.xml
+++ b/cycle_en_terre_custom/report/report_stockpicking_operations.xml
@@ -2,10 +2,10 @@
 <odoo>
     <data>
         <template id="report_picking" inherit_id="stock.report_picking">
-            <xpath expr="//tr[@t-as='package']" position="attributes">
-                <attribute name="t-foreach">o.entire_package_ids.sorted(key=lambda p: p.current_source_location_id.name)</attribute>
-                <attribute name="t-as">package</attribute>
+            <xpath expr="//div/table[last()-1]/tbody/tr" position="attributes">
+                <attribute name="t-foreach">o.move_lines.sorted(key=lambda m: m.move_line_ids[0].location_id.name if m.move_line_ids else None)</attribute>
+                <attribute name="t-as">move</attribute>
             </xpath>
         </template>
-        </data>
+    </data>
 </odoo>


### PR DESCRIPTION
# 12 - Gestion de stocks et étagères
> [task](https://gestion.coopiteasy.be/web#id=1317&view_type=form&model=project.task&action=479)

@houssine78 @remytms @mouloud42 

Je fais appel à l'équipe car j'ai déjà passé +/- 10h sur une tâche qui était estimée à 2h.

## Contexte
Le but est de trier les articles du bon de préparation par emplacement d'origine.

Le rapport est défini dans `stock/report/stock_report_views.xml` et le template dans `report_stockpicking_operations.xml`:

```xml
<report
    string="Picking Operations"
    id="action_report_picking"
    model="stock.picking"
    report_type="qweb-html"
    name="stock.report_picking"
    file="stock.report_picking_operations"
    print_report_name="'Picking Operations - %s - %s' % (object.partner_id.name or '', object.name)"
/>
```

Le tableau que je voudrais modifier est celui-ci:

```xml
<table class="table table-condensed" t-if="o.entire_package_ids and o.picking_type_entire_packs">
    <thead>
        <tr>
            <th width="25%">Package</th>
            <th width="25%" class="text-center">Barcode</th>
            <th width="25%" class="text-left">Source</th>
            <th width="25%" class="text-right">Destination</th>
        </tr>
    </thead>
    <tbody>
        <tr t-foreach="o.entire_package_ids.sorted(key=lambda p: p.current_source_location_id.name)" t-as="package">
            <t t-set="package" t-value="package.with_context({'picking_id':o.id})" />
            <td><span t-field="package.name"/></td>
            <td><img t-att-src="'/report/barcode/?type=%s&amp;value=%s&amp;width=%s&amp;height=%s' % ('Code128', package.name, 600, 100)" style="width:300px    ;height:50px"/></td>
            <td><span t-field="package.current_source_location_id"/></td>
            <td><span t-field="package.current_destination_location_id"/></td>
        </tr>
    </tbody>
</table>
```

## Héritage du rapport

J'ai créé dans le module `cycle_en_terre_custom` dans le répo _cycle_en_terre_, et j'y ai créé le fichier `report_stockpicking_operations.xml` avec le contenu suivant:


```xml
<?xml version="1.0" encoding="utf-8"?>
<odoo>
    <data>
        <template id="report_picking" inherit_id="stock.report_picking">
            <xpath expr="//table[@class='table table-condensed'][2]" position="replace">
                <div><span>AZERTY</span></div>
            </xpath>
        </template>
    </data>
</odoo>
```

Pour vérifier que je sélectionne bien le bon élément avec mon `xpath`, j'ai remplacé les éléments `table`, `tbody` et `tr` par des `<div>AZERTY</div>`: ça marche.

## Tentatives
### 1. Sélectionner `t-as`

Ceci n'a aucun effet

```xml
<xpath expr="//tr[@t-as='package']" position="attributes">
    <attribute name="t-foreach">o.entire_package_ids.sorted(key=lambda p: p.current_source_location_id.name)</attribute>
    <attribute name="t-as">package</attribute>
</xpath>
```

### 3. Remplacer `tbody`

Le but est de rmplacer le `key=lambda p: p.name` par `key=lambda p: p.current_source_location_id.name` mais ceci fait disparaitre le `tbody`:

```xml
<xpath expr="//table[@class='table table-condensed'][2]/tbody" position="replace">
    <tbody>
        <tr t-foreach="o.entire_package_ids.sorted(key=lambda p: p.name)" t-as="package">
            <t t-set="package" t-value="package.with_context({'picking_id':o.id})" />
            <td><span t-field="package.name"/></td>
            <td><img t-att-src="'/report/barcode/?type=%s&amp;value=%s&amp;width=%s&amp;height=%s' % ('Code128', package.name, 600, 100)" style="width:300px    ;height:50px"/></td>
            <td><span t-field="package.current_source_location_id"/></td>
            <td><span t-field="package.current_destination_location_id"/></td>
        </tr>
    </tbody>
</xpath>
```

J'ai aussi essayé de remplacer le table complet: même résultat.

### 3. Réordonner les `stock.quant.package`

J'ai aussi pensé à réordonner les `stock.quant.package` directement dans le backend mais `package.current_source_location_id` est un champ calculé.
J'ai bien pensé à le storer mais ça m'a l'air un peu dangereux et overkill.

## Pistes?

J'ai l'impression qu'il y a plusieurs inherit sur `report_picking` et que, du coup, ça cafouille un peu.
Avez-vous des pistes pour corriger les exemples ci-dessus ou pour faire autrement?

