### PR TITLE
 [IMP] cet_website_sale: Improve searching

### DIFF
--- a/cet_website_sale/__manifest__.py
+++ b/cet_website_sale/__manifest__.py
@@ -19,6 +19,7 @@
         "website_sale_category_breadcrumb",
         "website_sale_product_seeds",
         "product_seeds",
+        "base_search_fuzzy",
     ],
     "data": [
         "views/templates.xml",

--- a/cet_website_sale/controllers/main.py
+++ b/cet_website_sale/controllers/main.py
@@ -2,6 +2,8 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
 from odoo import http
+from odoo.http import request
+from odoo.osv import expression
 from odoo.addons.website_sale_product_seeds.controllers.main import (
     WebsiteSale as Base
 )
@@ -9,11 +11,53 @@ from odoo.addons.website_sale_product_seeds.controllers.main import (
 
 class WebsiteSale(Base):
 
+    def _get_search_domain(self, search, category, attrib_values):
+        """Extend the search to use fuzzy search.
+        And search also in the:
+            - categories
+            - latin name (see product_seeds)
+        """
+        domain = super()._get_search_domain(search, category, attrib_values)
+        # Remove sale product domain from domain
+        sale_domain = request.website.sale_product_domain()
+        for domain_elem, sale_domain_elem in zip(domain, sale_domain):
+            if domain_elem == sale_domain_elem:
+                domain.remove(domain_elem)
+        # Use '%' in place of 'ilike' for name search
+        for i, v in enumerate(domain):
+            if (isinstance(v, tuple) and len(v) == 3
+                    and (v[0] == 'name' and v[1] == 'ilike')):
+                domain[i] = (v[0], '%', v[2])
+        # Add new field in search domain
+        if search:
+            for word in search.split(" "):
+                # Latin name
+                domain = expression.OR([domain, [('latin_name', '%', word)]])
+                # Categories
+                category_mgr = request.env['product.public.category']
+                category_ids = category_mgr.sudo().search(
+                    [('name', '%', word)]
+                )
+                if category_ids:
+                    domain = expression.OR([
+                        domain,
+                        [('public_categ_ids', 'in', category_ids.ids)]
+                    ])
+        # Add sale product domain to domain
+        domain = sale_domain + domain
+        return domain
+
     @http.route()
     def shop(self, page=0, category=None, seedling_months=None, search='',
              ppg=False, **post):
+        # Set threshold for pg_trgm
+        # TODO: use a config to let user configure this value
+        threshold = 0.1
+        request.env.cr.execute("SELECT set_limit(%f);" % threshold)
+
         response = super().shop(page, category, seedling_months, search,
                                 ppg, **post)
+
         # Add element to context
         response.qcontext['get_attribute_value_ids'] = (
             self.get_attribute_value_ids

--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -1,1 +1,2 @@
 ecommerce https://github.com/coopiteasy/e-commerce.git 11.0
+server-tools https://github.com/coopiteasy/server-tools.git 11.0

--- a/website_sale_product_seeds/controllers/main.py
+++ b/website_sale_product_seeds/controllers/main.py
@@ -92,8 +92,8 @@ class WebsiteSale(Base):
 
         seedling_months = seedling_months_to_str(seedling_month_ids)
 
-        # Put supplier in the context so that it is accessible by other
-        # function of this controller.
+        # Put seedling months in the context so that it is accessible by
+        # other function of this controller.
         if seedling_month_ids:
             context = dict(request.env.context)
             context['seedling_month_ids'] = seedling_month_ids


### PR DESCRIPTION
Allow you to search latin name and also in categories.

Also enable fuzzy search.

In order to have fuzzy search working, install `base_search_fuzzy` form
OCA/server-tools. Then on the chosen DB run `CREATE EXTENSION pg_trgm;`.
Check also if `postgresql-contrib` is installed.