### PR TITLE
23 - A4 - bon de commande de vente et factures clients: ajout de champs label and weight

### DIFF
--- a/cycle_en_terre_custom/__init__.py
+++ b/cycle_en_terre_custom/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/cycle_en_terre_custom/__manifest__.py
+++ b/cycle_en_terre_custom/__manifest__.py
@@ -12,13 +12,19 @@
     'version': '11.0.0.0.1',
 
     'depends': [
+        'account',
+        'product_seeds',
         'stock',
         'sale',
     ],
 
     'data': [
+        'report/report_invoice.xml',
         'report/report_stockpicking_operations.xml',
         'report/sale_report.xml',
+        'views/account_invoice_views.xml',
+        'views/sale_views.xml',
+        'views/account_invoice_views.xml',
     ],
     'installable': True,
 }

--- a/cycle_en_terre_custom/models/__init__.py
+++ b/cycle_en_terre_custom/models/__init__.py
@@ -1,0 +1,2 @@
+from . import sale
+from . import account_invoice

--- a/cycle_en_terre_custom/models/account_invoice.py
+++ b/cycle_en_terre_custom/models/account_invoice.py
@@ -1,0 +1,18 @@
+from odoo import fields, models
+
+
+class AccountInvoiceLine(models.Model):
+    _inherit = "account.invoice.line"
+
+    label = fields.Char(
+        string='Label',
+        related='product_id.label',
+    )
+    seed_weight = fields.Float(
+        string='Seed Weight',
+        related='product_id.seed_weight',
+    )
+    weight_unit = fields.Many2one(
+        string='Weight Unit',
+        related='product_id.weight_unit',
+    )

--- a/cycle_en_terre_custom/models/sale.py
+++ b/cycle_en_terre_custom/models/sale.py
@@ -1,0 +1,19 @@
+
+from odoo import fields, models
+
+
+class SaleOrderLine(models.Model):
+    _inherit = 'sale.order.line'
+
+    label = fields.Char(
+        string='Label',
+        related='product_id.label',
+    )
+    seed_weight = fields.Float(
+        string='Seed Weight',
+        related='product_id.seed_weight',
+    )
+    weight_unit = fields.Many2one(
+        string='Weight Unit',
+        related='product_id.weight_unit',
+    )

--- a/cycle_en_terre_custom/report/report_invoice.xml
+++ b/cycle_en_terre_custom/report/report_invoice.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <template id="report_invoice_document" inherit_id="account.report_invoice_document">
+
+        <xpath expr="//table[@name='invoice_line_table']/thead/tr/th[1]" position="after">
+            <th>Label</th>
+            <th>Conditionnement</th>
+        </xpath>
+
+        <xpath expr="//table[@name='invoice_line_table']/tbody/tr[1]/td[1]" position="after">
+            <td class="text-right">
+                <t t-if="l.product_id.is_species">
+                    <span t-field="l.label"/>
+                </t>
+            </td>
+            <td class="text-right">
+                <t t-if="l.product_id.is_species">
+                    <span t-field="l.seed_weight"/>
+                    <span t-field="l.weight_unit"/>
+                </t>
+            </td>
+        </xpath>
+
+        <xpath expr="//t[@name='lines_layouted']//th[1]" position="after">
+            <th class="text-right">Label</th>
+            <th class="text-right">Conditionnement</th>
+        </xpath>
+
+        <xpath expr="//t[@name='lines_layouted']//td[2]" position="before">
+            <td class="text-right">
+                <t t-if="l.product_id.is_species">
+                    <span t-field="l.label"/>
+                </t>
+            </td>
+            <td class="text-right">
+                <t t-if="l.product_id.is_species">
+                    <span t-field="l.seed_weight"/>
+                    <span t-field="l.weight_unit"/>
+                </t>
+            </td>
+        </xpath>
+
+    </template>
+</odoo>

--- a/cycle_en_terre_custom/report/sale_report.xml
+++ b/cycle_en_terre_custom/report/sale_report.xml
@@ -6,17 +6,17 @@
                 <th class="text-right">Label</th>
                 <th class="text-right">Weight</th>
             </xpath>
-            
+
             <xpath expr="//tbody[hasclass('sale_tbody')]//t[@t-as='l']/tr/td[1]" position="after">
                 <td class="text-right">
                     <t t-if="l.product_id.is_species">
-                        <span t-field="l.product_id.label"/>
+                        <span t-field="l.label"/>
                     </t>
                 </td>
                 <td class="text-right">
                     <t t-if="l.product_id.is_species">
-                        <span t-field="l.product_id.seed_weight"/>
-                        <span t-field="l.product_id.weight_unit"/>
+                        <span t-field="l.seed_weight"/>
+                        <span t-field="l.weight_unit"/>
                     </t>
                 </td>
             </xpath>

--- a/cycle_en_terre_custom/views/account_invoice_views.xml
+++ b/cycle_en_terre_custom/views/account_invoice_views.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="invoice_form" model="ir.ui.view">
+            <field name="name">account.invoice.form</field>
+            <field name="model">account.invoice</field>
+            <field name="inherit_id" ref="account.invoice_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='invoice_line_ids']/tree/field[@name='name']" position="after">
+                    <field name="label"/>
+                    <field name="seed_weight"/>
+                    <field name="weight_unit"/>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</odoo>

--- a/cycle_en_terre_custom/views/sale_views.xml
+++ b/cycle_en_terre_custom/views/sale_views.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data>
+        <record id="view_order_form" model="ir.ui.view">
+            <field name="name">sale.order.form</field>
+            <field name="model">sale.order</field>
+            <field name="inherit_id" ref="sale.view_order_form"/>
+            <field name="arch" type="xml">
+                <xpath expr="//field[@name='order_line']//form//field[@name='product_id']" position="after">
+                    <field name="label"/>
+                    <field name="seed_weight"/>
+                    <field name="weight_unit"/>
+                </xpath>
+                <xpath expr="//field[@name='order_line']//tree//field[@name='name']" position="after">
+                    <field name="label"/>
+                    <field name="seed_weight"/>
+                    <field name="weight_unit"/>
+                </xpath>
+            </field>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
- [task](https://gestion.coopiteasy.be/web#id=1499&view_type=form&model=project.task)
- [specification](https://docs.google.com/document/d/1UZE2fbflUViAwufd-7KSiqMUEEG4eYK2mwZOCyM9jNw/edit)

J'invoque le @mouloud42! J'essaie d'ajouter des champs aux vue et rapports de `sale.order` et `account.invoice` (cf spec ci-dessus). Je cale sur l'ajout des champs au pdf de la facture. Le détail ci-dessous et dans [le dernier commit](https://github.com/coopiteasy/cycle-en-terre/pull/48/commits/db16c7b4c674f4f3ba36171e8231b00a95c07226).

## working
- [x] add related fields `label`, `seed_weight` and `weight_unit` to sale.order.line
- [x] add columns `label`, `seed_weight` and `weight_unit` to sale.order view
- [x] add columns `label`, `seed_weight` and `weight_unit` to sale.order report
- [x] add related fields `label`, `seed_weight` and `weight_unit` to account.invoice.line
- [x] add columns `label`, `seed_weight` and `weight_unit` to account.invoice view

## broken (last commit)
- [ ] add columns `label`, `seed_weight` and `weight_unit` to account.invoice report
  - cf comment in code review

## todo
- [ ] add licenses in files
