### PR TITLE
[FIX] cet_website_sale: Fix product view

### DIFF
--- a/cet_website_sale/views/website_sale_templates.xml
+++ b/cet_website_sale/views/website_sale_templates.xml
@@ -174,7 +174,7 @@
             </div>
           </form>
           <div class="panel-group" id="oe_collapse_product" role="tablist" aria-multiselectable="true">
-            <div class="panel panel-default">
+            <div t-if="product.description_sale" class="panel panel-default">
               <div class="panel-heading" role="tab" id="oe_collapse_p_description">
                 <h4 class="panel-title">
                   <a role="button" data-toggle="collapse" href="#oe_p_description" aria-expanded="true" aria-controls="oe_p_description">
@@ -188,10 +188,10 @@
                 </div>
               </div>
             </div>
-            <div class="panel panel-default">
+            <div t-if="product.species_information" class="panel panel-default">
               <div class="panel-heading" role="tab" id="oe_collapse_p_species_info">
                 <h4 class="panel-title">
-                  <a class="" role="button" data-toggle="collapse" href="#oe_p_species_info" aria-expanded="true" aria-controls="oe_p_species_info">
+                  <a role="button" data-toggle="collapse" href="#oe_p_species_info" aria-expanded="true" aria-controls="oe_p_species_info">
                     Species information
                   </a>
                 </h4>
@@ -203,7 +203,7 @@
               </div>
             </div>
             <div class="panel panel-default">
-              <div class="panel-heading" role="tab" id="oe_collapse_p_cult_info">
+              <div t-if="product.culture_information" class="panel-heading" role="tab" id="oe_collapse_p_cult_info">
                 <h4 class="panel-title">
                   <a role="button" data-toggle="collapse" href="#oe_p_cult_info" aria-expanded="true" aria-controls="oe_p_cult_info">
                     Culture Information
@@ -236,10 +236,6 @@
                         <label>Emergence (days):</label>
                         <span t-field="product.emergence"/>
                       </li>
-                      <li t-if="product.germination">
-                        <label>Germination:</label>
-                        <span t-field="product.germination"/>
-                      </li>
                       <li t-if="product.beemeadow">
                         <label>Beemeadow:</label>
                         <i class="fa fa-check"></i>
@@ -255,6 +251,10 @@
                       <li t-if="product.spacing_within_line">
                         <label>Spacing Within Lines:</label>
                         <span t-field="product.spacing_within_line"/>
+                      </li>
+                      <li t-if="product.density">
+                        <label>Density (g/10 m<sup>2</sup>):</label>
+                        <span t-field="product.density"/>
                       </li>
                       <li t-if="product.sowing_indoors_month_ids">
                         <label>Sowing Indoors Months:</label>
@@ -316,25 +316,13 @@
                           <t t-if="not sq_months_last">, </t>
                         </t>
                       </li>
-                      <li t-if="product.seedling_month_ids">
-                        <label>Seedling Months:</label>
-                        <t t-foreach="start_end_months(product.seedling_month_ids)" t-as="sq_months">
-                          <t t-if="len(sq_months) == 2">
-                            <t t-esc="sq_months[0].name"/> - <t t-esc="sq_months[1].name"/>
-                          </t>
-                          <t t-if="len(sq_months) == 1">
-                            <t t-esc="sq_months[0].name"/>
-                          </t>
-                          <t t-if="not sq_months_last">, </t>
-                        </t>
-                      </li>
                     </ul>
                   </div>
                 </div>
               </div>
             </div>
             <div class="oe_p_alt_button">
-              <a href="#oe_p_recipe" t-if="product.recipe">
+              <a href="#oe_p_recipe" t-if="product.recipe.replace('&lt;p&gt;&lt;br&gt;&lt;/p&gt;', '')">
                 <i class="fa fa-chevron-down"></i> Recipe
               </a>
             </div>
@@ -365,7 +353,7 @@
       </div>
       <!-- Recipe -->
       <div id="oe_p_recipe" class="oe_cet_pd_recipe oe_cet_pd_alt_section row"
-        t-if="product.recipe">
+        t-if="product.recipe.replace('&lt;p&gt;&lt;br&gt;&lt;/p&gt;', '')">
         <h2>Recipe</h2>
         <div class="col-xs-12 col-lg-6" t-field="product.recipe"/>
       </div>


### PR DESCRIPTION
Hide fields that are empty. Add a field and remove others.
The recipe field is never empty, because Odoo add `<p><br></p>`.