### PR TITLE
[ADD] cet_website_sale: Stock in e-commerce

### DIFF
--- a/cet_website_sale/controllers/main.py
+++ b/cet_website_sale/controllers/main.py
@@ -96,3 +96,23 @@ class WebsiteSale(Base):
             self.get_attribute_value_ids
         )
         return response
+
+    @http.route(['/shop/product/stock_info'], type='json', website=True,
+                auth='public')
+    def get_product_stock_info(self, **kwargs):
+        """Give a json data structure that contains informations about
+        the available stock for a product variant.
+        """
+        product_id = kwargs.get('id', None)
+        product = request.env['product.product'].sudo().browse(product_id)
+        if product:
+            return {
+                'id': product.id,
+                'virtual_available': product.virtual_available,
+                'inventory_availability': product.inventory_availability,
+                'available_threshold': product.available_threshold,
+                'custom_message': product.custom_message,
+                'cart_qty': product.cart_qty,
+            }
+        else:
+            return {'error': True}

--- a/cet_website_sale/static/src/js/stock.js
+++ b/cet_website_sale/static/src/js/stock.js
@@ -1,0 +1,83 @@
+odoo.define('cet_website_sale', function(require) {
+'use strict';
+
+require('web.dom_ready');
+var base = require('web_editor.base');
+var ajax = require('web.ajax');
+var core = require('web.core');
+
+var QWeb = core.qweb;
+
+if(!$('.oe_website_sale').length) {
+  return $.Deferred().reject("DOM doesn't contain '.oe_website_sale'");
+}
+
+$('.oe_website_sale').each(function() {
+  var oe_website_sale = this;
+
+  $(oe_website_sale).find('#oe_variant_ids_selector input')
+    .on('change', function(event) {
+      var input = this;
+
+      ajax.jsonRpc("/shop/product/stock_info",
+        'call',
+        {'id': parseInt($(input).attr("value"))})
+        .then(function(stock_info){
+          // Select element on the page
+          var js_product = $(input).closest('.js_product');
+          var qty_input = $(js_product).find('input[name="add_qty"]');
+          var qty = qty_input.val();
+
+          // Check only if the inventory_availability is 'always' or
+          // 'threshold'
+          if (stock_info['inventory_availability'] === 'always'
+              || stock_info['inventory_availability'] === 'threshold') {
+
+            // If there is a threshold, remove it from the available quantity
+            if (stock_info['inventory_availability'] === 'threshold') {
+              stock_info['virtual_available'] -= stock_info['available_threshold'];
+            }
+
+            // Remove quantity in a cart from the available quantity
+            stock_info['virtual_available'] -= parseInt(stock_info['cart_qty']);
+
+            // Set quantity to 0 in case of a negative value after
+            // computations
+            if (stock_info['virtual_available'] < 0) {
+              stock_info['virtual_available'] = 0;
+            }
+
+            // Prevent qty to grow above the available quantity
+            if (qty > stock_info['virtual_available']) {
+              qty = stock_info['virtual_available'] || 1;
+              qty_input.val(qty);
+            }
+
+            // Disable button "Add to cart"
+            var disable_condition = (
+              qty > stock_info['virtual_available']
+              || stock_info['virtual_available'] < 1
+              || qty < 1
+            );
+            $(js_product).find('#add_to_cart').toggleClass(
+              'disabled',
+              disable_condition
+            );
+
+            // Disable 'add quantity' button when reaching maximum
+            // available quantity.
+            $(js_product).find('.js_add').toggleClass(
+              'disabled btn',
+              stock_info['virtual_available'] - qty < 1
+            );
+            $(js_product).find('.js_remove').toggleClass(
+              'disabled btn',
+              qty <= 1
+            );
+          }
+        });
+    });
+
+});
+
+});

--- a/cet_website_sale/views/assets.xml
+++ b/cet_website_sale/views/assets.xml
@@ -20,6 +20,7 @@
         href="/cet_website_sale/static/src/less/product_variants.less"/>
       <link rel="stylesheet" type="text/less"
         href="/cet_website_sale/static/src/less/category_breadcrumb.less"/>
+      <script type="text/javascript" src="/cet_website_sale/static/src/js/stock.js"></script>
     </xpath>
   </template>
 

--- a/cet_website_sale/views/website_sale_templates.xml
+++ b/cet_website_sale/views/website_sale_templates.xml
@@ -59,11 +59,11 @@
                   <!-- Quantity Selector -->
                   <div class="oe_p_quantity">
                     <div class="css_quantity input-group oe_website_spinner" contenteditable="false">
-                      <a t-attf-href="#" class="mb8 input-group-addon js_add_cart_json">
+                      <a t-attf-href="#" class="mb8 input-group-addon js_add_cart_json js_remove">
                         <i class="fa fa-minus"></i>
                       </a>
                       <input type="text" class="form-control input-sm quantity" data-min="1" name="add_qty" value="1"/>
-                      <a t-attf-href="#" class="mb8 input-group-addon float_left js_add_cart_json">
+                      <a t-attf-href="#" class="mb8 input-group-addon float_left js_add_cart_json js_add">
                         <i class="fa fa-plus"></i>
                       </a>
                     </div>
@@ -159,11 +159,11 @@
                 <!-- Quantity Selector -->
                 <div class="oe_p_quantity pull-left">
                   <div class="css_quantity input-group oe_website_spinner" contenteditable="false">
-                    <a t-attf-href="#" class="mb8 input-group-addon js_add_cart_json">
+                    <a t-attf-href="#" class="mb8 input-group-addon js_add_cart_json js_remove">
                       <i class="fa fa-minus"></i>
                     </a>
                     <input type="text" class="form-control input-sm quantity" data-min="1" name="add_qty" value="1"/>
-                    <a t-attf-href="#" class="mb8 input-group-addon float_left js_add_cart_json">
+                    <a t-attf-href="#" class="mb8 input-group-addon float_left js_add_cart_json js_add">
                       <i class="fa fa-plus"></i>
                     </a>
                   </div>
@@ -392,7 +392,9 @@
     <t t-if="len(product.product_variant_ids) &gt; 1">
       <div class="oe_cet_product_variant">
         <t t-foreach="product.product_variant_ids" t-as="variant_id">
-          <div class="radio" t-if="variant_id.variant_sale_ok">
+          <div id="oe_variant_ids_selector"
+               class="radio"
+               t-if="variant_id.variant_sale_ok">
             <input type="radio" name="product_id"
               t-if="radio_position == 'before'"
               class="js_product_change radio-before"


### PR DESCRIPTION
Prevent ordering products that are not in stock, by disabling the
add-to-cart button for product with a stock under a certain threshold
and by disabling the quantity-add button when the maximum available
product is chosen.

This works when the product template is correctly configured.

To keep coherence, the module `website_sale_stock_options` should be
installed in order to prevent selling product without checking available
stock in the modal window and in the payment page.

This code is inspired by the `website_sale_stock` module.