### PR TITLE
[11.0][IMP] cet_website_sale: sort product variants by seed_weight

### DIFF
--- a/cet_website_sale/views/website_sale_templates.xml
+++ b/cet_website_sale/views/website_sale_templates.xml
@@ -41,7 +41,7 @@
                 <a itemprop="name" t-att-href="keep('/shop/product/%s' % slug(product), page=(pager['page']['num'] if pager['page']['num']&gt;1 else None))" t-att-content="product.name" t-field="product.name" />
               </div>
               <div class="oe_p_sub_name">
-                <t t-foreach="product.product_variant_ids" t-as="p">
+                <t t-foreach="product.product_variant_ids.sorted(key=lambda p: p.seed_weight)" t-as="p">
                   <span class="oe_p_ref" t-if="p.default_variant"># <t t-esc="p.default_code"/></span>
                 </t>
                 <span class="oe_p_latin_name" t-field="product.latin_name"/>
@@ -452,7 +452,7 @@
       <div class="oe_cet_product_variant">
 
         <!-- This part is hidden via css. -->
-        <t t-foreach="product.product_variant_ids" t-as="variant_id">
+        <t t-foreach="product.product_variant_ids.sorted(key=lambda p: p.seed_weight)" t-as="variant_id">
           <t t-if="not restrict_product or (restrict_product and variant_id in allowed_products)">
             <div class="radio oe_variant_ids_selector"
                  t-if="variant_id.variant_sale_ok"
@@ -487,7 +487,7 @@
 
         <!-- This select tag is just a wrapper that uses the input above -->
         <select class="oe_cet_product_variant_select js_product_change_select">
-          <t t-foreach="product.product_variant_ids" t-as="variant_id">
+          <t t-foreach="product.product_variant_ids.sorted(key=lambda p: p.seed_weight)" t-as="variant_id">
             <t t-if="not restrict_product or (restrict_product and variant_id in allowed_products)">
               <option t-if="variant_id.variant_sale_ok"
                   t-att-selected="'selected' if variant_id.default_variant else None"


### PR DESCRIPTION
[Task](https://gestion.coopiteasy.be/web#id=6467&view_type=form&model=project.task&action=479)

Before (alphabetical order) :
![cet_website_sale_before](https://user-images.githubusercontent.com/28013700/117658377-f0534100-b19a-11eb-82fc-81cf6bb3f5b5.gif)

After (seed weight order):
![cet_website_sale_after](https://user-images.githubusercontent.com/28013700/117658400-f6e1b880-b19a-11eb-8788-3b4ff3d63659.gif)

